### PR TITLE
Add workflow_dispatch trigger to CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write   # required to create GitHub Releases and upload assets


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` to the CD workflow's `on:` block, allowing it to be triggered manually from the GitHub Actions UI

## Test plan

- [x] Navigate to Actions → CD → Run workflow and confirm it can be triggered manually
