### PR TITLE
Fix NSIS relative paths by running makensis from installer\windows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -98,11 +98,12 @@ jobs:
       - name: Build Windows NSIS installer
         if: runner.os == 'Windows'
         shell: pwsh
+        working-directory: installer\windows
         run: |
           & "C:\Program Files (x86)\NSIS\makensis.exe" `
             /DVERSION=${{ needs.version.outputs.version }} `
             /V4 `
-            installer\windows\installer.nsi
+            installer.nsi
 
       # ── macOS: build PKG installer ──
       - name: Build macOS PKG installer


### PR DESCRIPTION
File and license paths in installer.nsi are relative to the script's own directory. Running makensis from the repo root caused them to resolve incorrectly. Set working-directory to installer\windows so paths like ..\..\dist and ..\..\LICENSE resolve as intended.