### PR TITLE
Fix NSIS file paths using REPO_ROOT define and explicit --distpath

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -88,6 +88,7 @@ jobs:
           --name "BookEditor"
           --product-name "Book Editor"
           --file-description "A desktop app for writing books with GitHub version control"
+          --distpath dist
 
       # ── Windows: build NSIS installer ──
       - name: Install NSIS (Windows)
@@ -102,6 +103,7 @@ jobs:
         run: |
           & "C:\Program Files (x86)\NSIS\makensis.exe" `
             /DVERSION=${{ needs.version.outputs.version }} `
+            /DREPO_ROOT=${{ github.workspace }} `
             /V4 `
             installer.nsi
 

--- a/installer/windows/installer.nsi
+++ b/installer/windows/installer.nsi
@@ -8,6 +8,10 @@
   !define VERSION "0.0.0"
 !endif
 
+!ifndef REPO_ROOT
+  !define REPO_ROOT "..\.."
+!endif
+
 Unicode True
 
 ; ── Modern UI ─────────────────────────────────────────────────────────────────
@@ -23,7 +27,7 @@ SetCompressor /SOLID lzma
 
 ; ── Pages ─────────────────────────────────────────────────────────────────────
 !insertmacro MUI_PAGE_WELCOME
-!insertmacro MUI_PAGE_LICENSE "..\..\LICENSE"
+!insertmacro MUI_PAGE_LICENSE "${REPO_ROOT}\LICENSE"
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
 !insertmacro MUI_PAGE_FINISH
@@ -90,7 +94,7 @@ Section "Book Editor" SecApp
   SectionIn RO   ; required — cannot be deselected
 
   SetOutPath "$INSTDIR"
-  File /r "..\..\dist\BookEditor\*.*"
+  File /r "${REPO_ROOT}\dist\BookEditor\*.*"
 
   ; Start Menu shortcuts
   CreateDirectory "$SMPROGRAMS\Book Editor"


### PR DESCRIPTION
Pass REPO_ROOT=${{ github.workspace }} to makensis so file paths in the NSIS script are absolute and unambiguous regardless of the working directory. Also add --distpath dist to flet pack to guarantee the output location. A fallback default of ..\.. keeps the script usable for local builds.