### PR TITLE
Add flet pack output inspection step to debug dist structure

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,6 +89,15 @@ jobs:
           --product-name "Book Editor"
           --file-description "A desktop app for writing books with GitHub version control"
 
+      - name: Show flet pack output structure (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Get-ChildItem -Recurse dist | Select-Object FullName
+
+      - name: Show flet pack output structure (macOS)
+        if: runner.os == 'macOS'
+        run: find dist -print
+
       # ── Windows: build NSIS installer ──
       - name: Install NSIS (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
Print the full dist/ directory tree on both Windows and macOS after flet pack runs, so we can see exactly what paths are produced before attempting to package them.