### PR TITLE
Fix remaining PopupMenuItem text= usages in version bump menu

### DIFF
--- a/src/book_editor/app.py
+++ b/src/book_editor/app.py
@@ -509,9 +509,9 @@ def main(page: ft.Page) -> None:
             ft.PopupMenuButton(
                 content=ft.Text("Bump version"),
                 items=[
-                    ft.PopupMenuItem(text="Minor", on_click=lambda e: tool_bump(e, "minor")),
-                    ft.PopupMenuItem(text="Patch", on_click=lambda e: tool_bump(e, "patch")),
-                    ft.PopupMenuItem(text="Major", on_click=lambda e: tool_bump(e, "major")),
+                    ft.PopupMenuItem(content=ft.Text("Minor"), on_click=lambda e: tool_bump(e, "minor")),
+                    ft.PopupMenuItem(content=ft.Text("Patch"), on_click=lambda e: tool_bump(e, "patch")),
+                    ft.PopupMenuItem(content=ft.Text("Major"), on_click=lambda e: tool_bump(e, "major")),
                 ],
             ),
             ft.ElevatedButton("Increment chapters", on_click=tool_increment),


### PR DESCRIPTION
The text= kwarg was removed in Flet 0.26. Replace with content=ft.Text() for the Minor/Patch/Major bump menu items missed in the previous fix.