### PR TITLE
Apply Anthropic brand styling + Python 3.9 compatibility fixes

### DIFF
--- a/src/book_editor/app.py
+++ b/src/book_editor/app.py
@@ -894,7 +894,7 @@ def main(page: ft.Page) -> None:
                 ft.Container(
                     ft.Row([
                         ft.Text("CHAPTERS", size=10, color=_TEXT_MUTED,
-                                weight=ft.FontWeight.W_600, letter_spacing=1.2),
+                                weight=ft.FontWeight.W_600),
                     ]),
                     padding=ft.padding.symmetric(horizontal=10, vertical=8),
                 ),


### PR DESCRIPTION
## Summary

- Applies Anthropic brand styling across all three app views (sign-in, repo selection, editor) using a dark palette with coral accent (#DA7756)
- Introduces reusable widget factory functions for consistent theming
- Fixes three Python 3.9 incompatible union type hints (`str | None`, `int | None`) that caused startup crashes
- Fixes `ft.Text(letter_spacing=...)` unsupported in Flet 0.28

## Design changes

- Background: #1A1A1A, Surface: #242424/#2C2C2C, Accent: #DA7756 coral
- Sign-in: Centered card with ✦ logo mark, coral device code in monospace
- Repo selection: Card layout, styled dropdown, coral CTA, ghost sign-out in red
- Editor: Full-bleed toolbar with ✦ Book Editor wordmark, CHAPTERS sidebar, active chapter highlighted with coral version text
- Save button: Shows `Save •` dot when dirty, dims to `Saving…` during push
- All dialogs: Dark background, rounded corners, styled action buttons

## Test plan

- [x] `bash run.sh` launches without errors on Python 3.9
- [x] Sign-in screen shows dark card with ✦ mark and coral button
- [x] Repo selection screen loads and populates dropdown
- [x] Editor loads with dark toolbar, sidebar, and monospace editor area
- [x] Typing in editor shows `Save •` dot on Save button
- [x] Saving a chapter shows `Saving…` then snackbar confirmation
