### PR TITLE
fix: correct Pandoc macOS download URL and internal zip path

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -133,11 +133,11 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           ARCH=$(uname -m)
-          curl -fsSL "https://github.com/jgm/pandoc/releases/download/3.6.2/pandoc-3.6.2-${ARCH}.zip" \
+          curl -fsSL "https://github.com/jgm/pandoc/releases/download/3.6.2/pandoc-3.6.2-${ARCH}-macOS.zip" \
                -o /tmp/pandoc.zip
           unzip -q /tmp/pandoc.zip -d /tmp/pandoc-bin
           mkdir -p dist/Beckit.app/Contents/Resources/bin
-          cp /tmp/pandoc-bin/pandoc-3.6.2/bin/pandoc \
+          cp /tmp/pandoc-bin/pandoc-3.6.2-${ARCH}/bin/pandoc \
              dist/Beckit.app/Contents/Resources/bin/pandoc
           chmod +x dist/Beckit.app/Contents/Resources/bin/pandoc
 


### PR DESCRIPTION
The macOS release filename is pandoc-3.6.2-{arch}-macOS.zip (not pandoc-3.6.2-{arch}.zip), and the zip's internal directory is pandoc-3.6.2-{arch}/ (not pandoc-3.6.2/).