### PR TITLE
fix: correct TinyTeX Windows bin path from win64 to windows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -116,8 +116,8 @@ jobs:
             -Uri "https://github.com/rstudio/tinytex-releases/releases/download/daily/TinyTeX-1.zip" `
             -OutFile "$env:TEMP\tinytex.zip"
           Expand-Archive "$env:TEMP\tinytex.zip" -DestinationPath "$env:TEMP\tinytex-extract" -Force
-          $tinytexDir = (Get-ChildItem "$env:TEMP\tinytex-extract" | Select-Object -First 1).FullName
-          $tlmgr = "$tinytexDir\bin\win64\tlmgr.bat"
+          $tinytexDir = "$env:TEMP\tinytex-extract\TinyTeX"
+          $tlmgr = "$tinytexDir\bin\windows\tlmgr.bat"
           & $tlmgr install geometry fancyhdr hyperref xcolor caption float listings lm booktabs
           Copy-Item -Recurse -Force "$tinytexDir" "dist\Beckit\tinytex"
 

--- a/src/book_editor/services/pdf_build.py
+++ b/src/book_editor/services/pdf_build.py
@@ -67,7 +67,7 @@ def _augmented_env() -> dict:
                 extra.append(str(tinytex_bin))
         elif sys.platform == "win32":
             extra.append(str(res / "bin"))
-            tinytex_bin = res / "tinytex" / "bin" / "win64"
+            tinytex_bin = res / "tinytex" / "bin" / "windows"
             if tinytex_bin.exists():
                 extra.append(str(tinytex_bin))
 


### PR DESCRIPTION
The TinyTeX-1.zip for Windows extracts to TinyTeX\ with binaries at bin\windows\, not bin\win64\ as previously assumed. Also replace the fragile Get-ChildItem dir-detection with a direct hardcoded path since the zip always extracts to TinyTeX\.

Fixes tlmgr.bat not found and updates pdf_build.py _augmented_env() to use the correct bin\windows path at runtime.