### PR TITLE
feat: PDF generation improvements — save dialog, Save & Open, auto-in…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "beckit"
-version = "3.1.0"
+version = "3.1.1"
 description = "Lightweight cross-platform book writing app with GitHub sync and chapter versioning"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/book_editor/services/pdf_build.py
+++ b/src/book_editor/services/pdf_build.py
@@ -184,21 +184,27 @@ def build_pdf(
 
 def check_pandoc_available() -> bool:
     """Return True if pandoc is available (bundled or on PATH)."""
-    result = subprocess.run(
-        [_resolve_bin("pandoc"), "--version"],
-        capture_output=True,
-        text=True,
-        env=_augmented_env(),
-    )
-    return result.returncode == 0
+    try:
+        result = subprocess.run(
+            [_resolve_bin("pandoc"), "--version"],
+            capture_output=True,
+            text=True,
+            env=_augmented_env(),
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
 
 
 def check_pdflatex_available() -> bool:
     """Return True if pdflatex is available (bundled or on PATH)."""
-    result = subprocess.run(
-        ["pdflatex", "--version"],
-        capture_output=True,
-        text=True,
-        env=_augmented_env(),
-    )
-    return result.returncode == 0
+    try:
+        result = subprocess.run(
+            [_resolve_bin("pdflatex"), "--version"],
+            capture_output=True,
+            text=True,
+            env=_augmented_env(),
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False


### PR DESCRIPTION
## Summary

  - **Native save dialog**: "Choose…" button opens a native OS file picker
    (osascript on macOS, PowerShell on Windows, zenity on Linux) — works
    reliably where Flet's built-in FilePicker was blocked by the modal dialog
  - **Save & Open**: New button generates the PDF and immediately opens it
    in the system viewer
  - **Dependency auto-install**: `run.sh` now checks for pandoc and
    mactex-no-gui and installs them via Homebrew on first run, so testers
    don't need to set up dependencies manually
  - **Availability check fixes**: `check_pandoc_available()` and
    `check_pdflatex_available()` now catch `FileNotFoundError` correctly;
    pdflatex check resolves the bundled TinyTeX path via `_resolve_bin()`

  ## Test plan

  - [ ] Open Generate PDF dialog — title/author fields with Choose…, Save & Open, Save buttons
  - [ ] Click Choose… — native macOS save dialog appears; picking a file updates the label
  - [ ] Cancel the OS dialog — Beckit dialog remains open unchanged
  - [ ] Click Save — PDF saved to chosen location; snackbar confirms path
  - [ ] Click Save & Open — PDF generated and opened in Preview immediately
  - [ ] With no path chosen, Save uses default project folder
  - [ ] On a machine without pandoc/mactex, `run.sh` installs them automatically