### PR TITLE
Add Front Matter and Back Matter Sections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## What does this PR do?
+
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Docs / assets
+
+## How to test
+
+
+## Screenshots (if applicable)

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,4 @@ htmlcov/
 .pytest_cache/
 
 # Local dev scripts
-run.sh
 *.spec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ format-markdown = "book_editor.services.format_markdown:main"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+book_editor = ["data/*.txt"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+# Create virtual environment if it doesn't exist
+if [ ! -d ".venv" ]; then
+  echo "Creating virtual environment..."
+  python3 -m venv .venv
+fi
+
+source .venv/bin/activate
+
+# Install/update dependencies
+pip install -e . --quiet
+pip install flet --quiet
+
+# ── Optional PDF-generation dependencies ──────────────────────────────────────
+# pandoc and pdflatex are required only for Generate PDF.  Install them via
+# Homebrew if missing.  Skipped gracefully when Homebrew is not available.
+
+_need_pandoc=0
+_need_mactex=0
+
+command -v pandoc &>/dev/null || _need_pandoc=1
+
+# pdflatex may be in /Library/TeX/texbin even when not yet on PATH
+if ! command -v pdflatex &>/dev/null && ! [ -x /Library/TeX/texbin/pdflatex ]; then
+  _need_mactex=1
+fi
+
+if [ "$_need_pandoc" -eq 1 ] || [ "$_need_mactex" -eq 1 ]; then
+  if ! command -v brew &>/dev/null; then
+    echo "WARNING: Homebrew not found — skipping automatic dependency install."
+    echo "  For PDF export, install pandoc and MacTeX manually, then re-run run.sh:"
+    echo "    https://brew.sh"
+  else
+    if [ "$_need_pandoc" -eq 1 ]; then
+      echo "Installing pandoc (required for PDF export)..."
+      brew install pandoc
+    fi
+    if [ "$_need_mactex" -eq 1 ]; then
+      echo "Installing mactex-no-gui (required for PDF export, ~300 MB one-time download)..."
+      brew install --cask mactex-no-gui
+      # Add TeX binaries to PATH for the remainder of this session
+      export PATH="/Library/TeX/texbin:$PATH"
+    fi
+  fi
+fi
+
+# Patch the Flet viewer's Info.plist so the macOS menu bar shows "Beckit"
+# instead of "Flet". The viewer is cached in ~/.flet/bin/ and may be
+# re-downloaded when the flet version changes, so we patch on every launch.
+FLET_BIN_DIR="$HOME/.flet/bin"
+if [ -d "$FLET_BIN_DIR" ]; then
+  for flet_app in "$FLET_BIN_DIR"/*/Flet.app/Contents/Info.plist; do
+    if [ -f "$flet_app" ]; then
+      /usr/libexec/PlistBuddy -c "Set :CFBundleName Beckit" "$flet_app" 2>/dev/null || true
+      /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName Beckit" "$flet_app" 2>/dev/null \
+        || /usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string Beckit" "$flet_app" 2>/dev/null || true
+    fi
+  done
+fi
+
+# Run the app
+python3 -m book_editor

--- a/src/book_editor/app.py
+++ b/src/book_editor/app.py
@@ -1,6 +1,7 @@
 """Flet UI for the Beckit desktop app."""
 
 import os
+import random
 import re
 import subprocess
 import sys
@@ -46,6 +47,11 @@ from book_editor.services import (
     check_pandoc_available,
     check_pdflatex_available,
     classify_change,
+    FRONT_MATTER_ORDER,
+    BACK_MATTER_ORDER,
+    list_matter_sections,
+    create_matter_section,
+    delete_matter_section,
     ensure_planning_structure,
     list_planning_files,
     create_planning_file,
@@ -65,6 +71,18 @@ _TEXT    = "#F5F0EB"
 _TEXT_MUTED = "#A09890"
 _BORDER  = "#383838"
 _ERROR   = "#E05C5C"
+
+
+def _repo_name_to_title(repo_name: str) -> str:
+    """Convert 'in-the-presence-of-power-most-foul' → 'In the Presence of Power Most Foul'."""
+    words = re.split(r"[-_]+", repo_name)
+    return " ".join(w.capitalize() for w in words if w)
+
+
+def _title_to_repo_name(title: str) -> str:
+    """Convert 'In the Presence of Power Most Foul' → 'in-the-presence-of-power-most-foul'."""
+    slug = re.sub(r"[^\w\s-]", "", title.lower())
+    return re.sub(r"[\s_]+", "-", slug).strip("-")
 
 
 def _log(label: str, ex: BaseException) -> None:
@@ -304,7 +322,8 @@ def main(page: ft.Page) -> None:
         visible=False, color=_ACCENT, stroke_width=2, width=18, height=18
     )
     repo_error = ft.Text("", color=_ERROR, size=13)
-    create_repo_name_field = _styled_field("Repository name", width=300)
+    create_repo_name_field = _styled_field("Book title", width=300)
+    create_repo_name_preview = ft.Text("", size=11, color=_TEXT_MUTED)
     create_private_check = ft.Checkbox(
         label="Private repository", value=True, active_color=_ACCENT,
         label_style=ft.TextStyle(color=_TEXT_MUTED, size=13),
@@ -373,16 +392,25 @@ def main(page: ft.Page) -> None:
 
     def open_create_repo_dialog(e):
         create_repo_name_field.value = ""
+        create_repo_name_preview.value = ""
         create_private_check.value = True
 
+        def _update_repo_preview(e2):
+            slug = _title_to_repo_name(create_repo_name_field.value or "")
+            create_repo_name_preview.value = f"Repo name: {slug}" if slug else ""
+            page.update()
+
+        create_repo_name_field.on_change = _update_repo_preview
+
         def do_create(e2):
-            name = (create_repo_name_field.value or "").strip()
-            if not name:
-                page.open(ft.SnackBar(ft.Text("Enter a repository name.")))
+            title = (create_repo_name_field.value or "").strip()
+            if not title:
+                page.open(ft.SnackBar(ft.Text("Enter a book title.")))
                 page.update()
                 return
-            if not re.match(r"^[a-zA-Z0-9_.-]+$", name):
-                page.open(ft.SnackBar(ft.Text("Use only letters, numbers, - and _.")))
+            name = _title_to_repo_name(title)
+            if not name:
+                page.open(ft.SnackBar(ft.Text("Title couldn't be converted to a valid repo name.")))
                 page.update()
                 return
             token = token_holder.get("value") or load_config().get("github_token") or ""
@@ -406,10 +434,11 @@ def main(page: ft.Page) -> None:
 
         dlg = ft.AlertDialog(
             bgcolor=_SURFACE,
-            title=_heading("Create new repository", size=18),
+            title=_heading("Create new book", size=18),
             content=ft.Container(
                 ft.Column(
-                    [create_repo_name_field, ft.Container(height=8), create_private_check],
+                    [create_repo_name_field, create_repo_name_preview,
+                     ft.Container(height=4), create_private_check],
                     tight=True,
                 ),
                 width=320,
@@ -479,6 +508,13 @@ def main(page: ft.Page) -> None:
 
     # ── Editor ────────────────────────────────────────────────────────────────
     repo_path_holder = {"value": get_repo_path(config)}
+    book_title_text = ft.Text(
+        "", size=12, weight=ft.FontWeight.W_600,
+        color=_TEXT, overflow=ft.TextOverflow.ELLIPSIS,
+    )
+
+    front_matter_list = ft.Column([], spacing=0)
+    back_matter_list  = ft.Column([], spacing=0)
 
     # Dual-mode state: "preview" shows ft.Markdown, "edit" shows ft.TextField
     editor_mode = {"value": "preview"}  # "preview" | "edit"
@@ -906,6 +942,43 @@ def main(page: ft.Page) -> None:
     status_total_words = ft.Text("", size=12, color=_TEXT_MUTED)
     save_indicator = ft.Text("", size=12, color=_TEXT_MUTED)
 
+    # ── Book facts ticker ─────────────────────────────────────────────────────
+    _facts_path = Path(__file__).parent / "data" / "book_facts.txt"
+    try:
+        _book_facts = [
+            line.strip()
+            for line in _facts_path.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.startswith("#")
+        ]
+    except Exception:
+        _book_facts = []
+
+    if _book_facts:
+        random.shuffle(_book_facts)
+
+    _fact_idx = {"value": 0}
+    fact_text = ft.Text(
+        _book_facts[0] if _book_facts else "",
+        size=11, color=_TEXT_MUTED, italic=True,
+        overflow=ft.TextOverflow.ELLIPSIS,
+        text_align=ft.TextAlign.CENTER,
+        expand=True,
+    )
+
+    def _rotate_facts():
+        while True:
+            time.sleep(15)
+            if not _book_facts:
+                continue
+            _fact_idx["value"] = (_fact_idx["value"] + 1) % len(_book_facts)
+            fact_text.value = _book_facts[_fact_idx["value"]]
+            try:
+                page.update()
+            except Exception:
+                pass
+
+    threading.Thread(target=_rotate_facts, daemon=True).start()
+
     def _mark_dirty(dirty: bool):
         """Update dirty state and save indicator without calling page.update()."""
         editor_dirty["value"] = dirty
@@ -967,7 +1040,12 @@ def main(page: ft.Page) -> None:
         edit_layer.visible = False
         _scratch_placeholder.visible = False
         m = re.search(r"[Cc]hapter\s+(\d+)", str(md_path))
-        chap_label = f"Chapter {m.group(1)}" if m else md_path.stem
+        if m:
+            chap_label = f"Chapter {m.group(1)}"
+        else:
+            # FrontMatter/Copyright/v1.0.0/v1.0.0.md → section dir is parent.parent
+            section_dir = Path(str(md_path)).parent.parent
+            chap_label = section_dir.name
         status_chapter.value = chap_label
         chapter_panel_title.value = chap_label
         history_btn.visible = True
@@ -975,6 +1053,8 @@ def main(page: ft.Page) -> None:
         _update_word_count_internal()
         _update_total_word_count_internal()
         refresh_chapter_list()
+        refresh_front_matter_list()
+        refresh_back_matter_list()
 
     def load_chapter_file(md_path: Path):
         """Load a chapter, prompting to save/discard scratch content first if needed."""
@@ -1070,8 +1150,8 @@ def main(page: ft.Page) -> None:
 
         if bump_type is not None:
             # Create a new version directory for meaningful changes
-            chapter_dir = current_path.parent.parent   # .../Chapter 1
-            chapters_root = chapter_dir.parent          # .../Chapters
+            chapter_dir = current_path.parent.parent   # .../Chapter 1 or .../Copyright
+            chapters_root = chapter_dir.parent          # .../Chapters or .../FrontMatter
             m = re.search(r"[Cc]hapter\s+(\d+)", chapter_dir.name)
             if m:
                 try:
@@ -1081,8 +1161,19 @@ def main(page: ft.Page) -> None:
                     current_md_path["value"] = str(new_md)
                 except Exception:
                     pass  # content already written in-place — no data loss
+            else:
+                # matter section
+                try:
+                    manager = ChapterVersionManager(str(chapters_root))
+                    new_ver_dir = manager.bump_section_dir(chapter_dir, bump_type)
+                    new_md = manager.get_markdown_file(new_ver_dir)
+                    current_md_path["value"] = str(new_md)
+                except Exception:
+                    pass  # content already written — no data loss
 
         refresh_chapter_list()
+        refresh_front_matter_list()
+        refresh_back_matter_list()
         _set_dirty(False)
         save_indicator.value = "Syncing…"
         save_indicator.color = _TEXT_MUTED
@@ -1608,18 +1699,206 @@ def main(page: ft.Page) -> None:
             )
         page.update()
 
+    def _matter_section_row(kind: str, name: str, md_path: Path, ver: str) -> ft.Container:
+        is_active = (current_md_path["value"] == md_path)
+
+        def _confirm_delete(e, _kind=kind, _name=name):
+            def _do_delete(e2):
+                page.close(dlg)
+                try:
+                    delete_matter_section(repo_path_holder["value"], _kind, _name)
+                except Exception as ex:
+                    page.open(ft.SnackBar(ft.Text(str(ex))))
+                    page.update()
+                    return
+                if _kind == "front":
+                    refresh_front_matter_list()
+                else:
+                    refresh_back_matter_list()
+                page.update()
+
+            dlg = ft.AlertDialog(
+                bgcolor=_SURFACE, modal=True,
+                title=_heading(f'Delete "{_name}"?', size=18),
+                content=ft.Container(
+                    ft.Text("This will permanently remove the section folder.", color=_TEXT_MUTED, size=13),
+                    width=280,
+                ),
+                actions=[
+                    _ghost_btn("Cancel", on_click=lambda e2: page.close(dlg)),
+                    ft.TextButton(
+                        "Delete",
+                        on_click=_do_delete,
+                        style=ft.ButtonStyle(
+                            color={ft.ControlState.DEFAULT: _ERROR,
+                                   ft.ControlState.HOVERED: "#FF7070"},
+                            padding=ft.padding.symmetric(horizontal=12, vertical=8),
+                        ),
+                    ),
+                ],
+                shape=ft.RoundedRectangleBorder(radius=10),
+            )
+            page.open(dlg)
+            page.update()
+
+        return ft.Container(
+            content=ft.Row(
+                [
+                    ft.Container(
+                        ft.Column(
+                            [
+                                ft.Text(
+                                    name,
+                                    size=12,
+                                    color=_TEXT if is_active else _TEXT_MUTED,
+                                    weight=ft.FontWeight.W_500 if is_active else ft.FontWeight.NORMAL,
+                                    overflow=ft.TextOverflow.ELLIPSIS,
+                                ),
+                                ft.Text(
+                                    ver, size=10,
+                                    color=_ACCENT if is_active else _BORDER,
+                                ),
+                            ],
+                            spacing=1, tight=True,
+                        ),
+                        expand=True,
+                        on_click=lambda e, p=md_path: load_chapter_file(p),
+                        padding=ft.padding.symmetric(vertical=7),
+                        ink=True,
+                        bgcolor=_SURFACE2 if is_active else None,
+                        border_radius=4,
+                    ),
+                    ft.IconButton(
+                        icon=ft.Icons.CLOSE,
+                        icon_size=12,
+                        icon_color=_BORDER,
+                        tooltip=f"Delete {name}",
+                        on_click=_confirm_delete,
+                        style=ft.ButtonStyle(
+                            padding=ft.padding.all(4),
+                            overlay_color={ft.ControlState.HOVERED: "#33E05C5C"},
+                        ),
+                    ),
+                ],
+                spacing=0,
+                vertical_alignment=ft.CrossAxisAlignment.CENTER,
+            ),
+            padding=ft.padding.symmetric(horizontal=4),
+        )
+
+    def refresh_front_matter_list():
+        path = repo_path_holder["value"]
+        front_matter_list.controls.clear()
+        if not path:
+            page.update()
+            return
+        for name, md_path in list_matter_sections(path, "front"):
+            ver = md_path.parent.name
+            front_matter_list.controls.append(
+                _matter_section_row("front", name, md_path, ver)
+            )
+        page.update()
+
+    def refresh_back_matter_list():
+        path = repo_path_holder["value"]
+        back_matter_list.controls.clear()
+        if not path:
+            page.update()
+            return
+        for name, md_path in list_matter_sections(path, "back"):
+            ver = md_path.parent.name
+            back_matter_list.controls.append(
+                _matter_section_row("back", name, md_path, ver)
+            )
+        page.update()
+
+    def open_add_matter_dialog(kind: str):
+        path = repo_path_holder["value"]
+        if not path:
+            return
+        order = FRONT_MATTER_ORDER if kind == "front" else BACK_MATTER_ORDER
+        existing = {name for name, _ in list_matter_sections(path, kind)}
+        available = [n for n in order if n not in existing]
+        if not available:
+            page.open(ft.SnackBar(ft.Text("All sections already added.")))
+            page.update()
+            return
+
+        dd = ft.Dropdown(
+            options=[ft.dropdown.Option(n) for n in available],
+            value=available[0],
+            bgcolor=_SURFACE2,
+            color=_TEXT,
+            border_color=_BORDER,
+            focused_border_color=_ACCENT,
+            width=240,
+        )
+
+        def do_add(e2):
+            chosen = dd.value
+            if not chosen:
+                return
+            try:
+                new_md = create_matter_section(path, kind, chosen)
+                page.close(dlg)
+                if kind == "front":
+                    refresh_front_matter_list()
+                else:
+                    refresh_back_matter_list()
+                load_chapter_file(new_md)
+            except Exception as ex:
+                page.open(ft.SnackBar(ft.Text(str(ex))))
+            page.update()
+
+        dlg = ft.AlertDialog(
+            bgcolor=_SURFACE,
+            title=_heading("Add section", size=18),
+            content=ft.Container(dd, width=260),
+            actions=[
+                _ghost_btn("Cancel", on_click=lambda e2: page.close(dlg)),
+                _primary_btn("Add", on_click=do_add),
+            ],
+            shape=ft.RoundedRectangleBorder(radius=10),
+        )
+        page.open(dlg)
+        page.update()
+
+    def _matter_section_header(label: str, kind: str) -> ft.Container:
+        return ft.Container(
+            ft.Row(
+                [
+                    ft.Text(label, size=11, color=_TEXT_MUTED, weight=ft.FontWeight.W_500),
+                    ft.Container(expand=True),
+                    ft.IconButton(
+                        icon=ft.Icons.ADD,
+                        icon_size=14,
+                        icon_color=_TEXT_MUTED,
+                        tooltip=f"Add {label} section",
+                        on_click=lambda e, k=kind: open_add_matter_dialog(k),
+                        style=ft.ButtonStyle(padding=ft.padding.all(4)),
+                    ),
+                ],
+                vertical_alignment=ft.CrossAxisAlignment.CENTER,
+            ),
+            padding=ft.padding.only(left=12, right=4, top=6, bottom=2),
+        )
+
     sidebar = ft.Container(
         ft.Column(
             [
                 ft.Container(
-                    ft.Row(
-                        [
-                            ft.Text("Chapters", size=11, color=_TEXT_MUTED,
-                                    weight=ft.FontWeight.W_500),
-                        ],
-                        alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
-                    ),
-                    padding=ft.padding.only(left=12, right=8, top=14, bottom=8),
+                    book_title_text,
+                    padding=ft.padding.only(left=12, right=8, top=12, bottom=2),
+                ),
+                # Front Matter
+                _matter_section_header("Front Matter", "front"),
+                ft.Container(front_matter_list, padding=ft.padding.only(bottom=2)),
+                ft.Divider(height=1, color=_BORDER),
+                # Chapters
+                ft.Container(
+                    ft.Text("Chapters", size=11, color=_TEXT_MUTED,
+                            weight=ft.FontWeight.W_500),
+                    padding=ft.padding.only(left=12, right=8, top=6, bottom=4),
                 ),
                 ft.Container(chapter_reorder_list, expand=True),
                 ft.Container(
@@ -1632,11 +1911,16 @@ def main(page: ft.Page) -> None:
                             padding=ft.padding.symmetric(horizontal=12, vertical=6),
                         ),
                     ),
-                    padding=ft.padding.only(bottom=8),
+                    padding=ft.padding.only(bottom=4),
                 ),
+                ft.Divider(height=1, color=_BORDER),
+                # Back Matter
+                _matter_section_header("Back Matter", "back"),
+                ft.Container(back_matter_list, padding=ft.padding.only(bottom=8)),
             ],
             spacing=0,
             expand=True,
+            scroll=ft.ScrollMode.AUTO,
         ),
         width=172,
         bgcolor=_SURFACE,
@@ -1705,6 +1989,8 @@ def main(page: ft.Page) -> None:
         _update_word_count_internal()
         _update_total_word_count_internal()
         refresh_chapter_list()
+        refresh_front_matter_list()
+        refresh_back_matter_list()
 
     history_btn = ft.IconButton(
         icon=ft.Icons.HISTORY,
@@ -2279,7 +2565,9 @@ def main(page: ft.Page) -> None:
                 status_words,
                 ft.Container(width=12),
                 status_total_words,
-                ft.Container(expand=True),
+                ft.Container(width=16),
+                fact_text,
+                ft.Container(width=16),
                 save_indicator,
                 ft.Container(width=12),
                 ft.TextButton(
@@ -2380,6 +2668,8 @@ def main(page: ft.Page) -> None:
 
             _slog("Startup pull: done — refreshing sidebar")
             refresh_chapter_list()
+            refresh_front_matter_list()
+            refresh_back_matter_list()
             refresh_planning_list()
             save_indicator.value = ""
             page.update()
@@ -2402,8 +2692,18 @@ def main(page: ft.Page) -> None:
             )
             on_repo_view_visible()
         elif page.route == "/editor":
+            repo_name = cfg.get("repo_name", "")
+            if repo_name:
+                _title = _repo_name_to_title(repo_name)
+                book_title_text.value = _title
+                page.title = f"Beckit — {_title}"
+            else:
+                book_title_text.value = ""
+                page.title = "Beckit"
             if repo_path_holder["value"]:
                 refresh_chapter_list()
+                refresh_front_matter_list()
+                refresh_back_matter_list()
             # Start with a blank scratch pad if no chapter is loaded
             if current_md_path["value"] is None:
                 md_content["value"] = ""

--- a/src/book_editor/data/book_facts.txt
+++ b/src/book_editor/data/book_facts.txt
@@ -1,0 +1,160 @@
+# Book Facts & Formatting Tips
+# One fact per line. Blank lines and lines starting with # are ignored.
+
+# ── Word Counts by Genre ─────────────────────────────────────────────────────
+Genre fiction (thrillers, romance, horror) typically runs 80,000–100,000 words.
+Literary fiction averages 80,000–110,000 words, with more room for longer works.
+Young adult (YA) fiction targets 55,000–80,000 words.
+Middle grade fiction falls between 20,000 and 55,000 words.
+Epic fantasy novels often exceed 120,000 words — Tolkien's The Fellowship of the Ring is ~177,000.
+Commercial fantasy typically targets 100,000–120,000 words for debut authors.
+Science fiction averages 90,000–120,000 words.
+Historical fiction tends to run longer, averaging 100,000–150,000 words.
+Romance novels average 50,000–100,000 words depending on subgenre.
+Category romance (Harlequin-style) is tightly constrained to 55,000–60,000 words.
+Cozy mysteries typically run 65,000–90,000 words.
+Hard-boiled crime fiction averages 70,000–90,000 words.
+Psychological thrillers tend to fall between 80,000 and 100,000 words.
+Women's fiction averages 85,000–100,000 words.
+Chick-lit targets 80,000–95,000 words.
+Horror novels average 80,000–100,000 words.
+Paranormal romance typically runs 85,000–100,000 words.
+New adult fiction targets 60,000–85,000 words.
+Children's chapter books run 10,000–30,000 words.
+Picture book texts are usually under 1,000 words — often closer to 500.
+Novellas are typically 17,500–40,000 words.
+Novelettes run 7,500–17,500 words.
+Short stories are generally under 7,500 words.
+Flash fiction is under 1,000 words.
+Narrative nonfiction averages 70,000–90,000 words.
+Self-help books typically run 45,000–80,000 words.
+Business books average 50,000–80,000 words.
+Memoir averages 70,000–90,000 words.
+Biography averages 80,000–120,000 words.
+Prescriptive nonfiction (how-to) often runs 50,000–70,000 words.
+Academic monographs typically run 80,000–120,000 words.
+
+# ── Words Per Page ───────────────────────────────────────────────────────────
+A mass market paperback averages 250–300 words per page.
+A trade paperback averages 250–275 words per page.
+A hardcover averages 250–300 words per page, depending on trim size and font.
+Standard manuscript format (12pt Times New Roman, double-spaced) yields ~250 words per page.
+Publishers estimate roughly 300 words per printed page for production planning.
+A 300-page mass market paperback contains approximately 80,000–90,000 words.
+A typical 400-page novel contains approximately 100,000–120,000 words in print.
+Larger trim sizes (6×9 trade) can fit 300–350 words per page.
+Smaller trim sizes (4.19×6.75 mass market) fit roughly 250–280 words per page.
+Ebooks have no fixed "page" — word count is the only reliable length metric.
+An audiobook runs approximately 9,300 words per hour at average narration speed.
+A 100,000-word audiobook takes roughly 10–11 hours to produce and listen to.
+
+# ── Front Matter ─────────────────────────────────────────────────────────────
+Front matter is everything that appears before Chapter 1, numbered in Roman numerals.
+The half title page (bastard title) contains only the book's main title — no subtitle or author name.
+The full title page carries the complete title, subtitle, author name, and publisher imprint.
+The copyright page is usually the verso (back) of the full title page.
+The copyright page includes the copyright year, owner, edition, ISBN, Library of Congress data, and legal disclaimers.
+A dedication is a brief tribute, usually to a person or persons meaningful to the author.
+A dedication typically runs 1–3 lines and needs no heading — placement implies its purpose.
+An epigraph is a quotation placed at the opening of a book or chapter to set tone or theme.
+An epigraph is attributed below the quote, often in italics, preceded by an em dash.
+A foreword is written by someone other than the author — usually a notable person who vouches for the work.
+A preface is written by the author, explaining how and why the book came to be.
+An introduction presents the book's argument or subject — it is part of the text, not front matter preamble.
+A prologue is part of the narrative itself, set before Chapter 1, often introducing backstory or a flash-forward.
+A table of contents is standard in nonfiction; in fiction it is optional but common in multi-part works.
+An acknowledgments section can appear in either front matter or back matter — back matter is more common today.
+
+# ── Back Matter ──────────────────────────────────────────────────────────────
+Back matter follows the last chapter and is numbered with Arabic numerals continuing from the text.
+An epilogue is part of the narrative, set after the main story concludes — it is not back matter.
+An afterword is the author's reflection written after the story, discussing themes or context.
+An author's note clarifies what is fact vs. fiction, especially important in historical or biographical novels.
+An acknowledgments section is where authors thank editors, agents, beta readers, friends, and family.
+A bibliography lists sources consulted; standard in nonfiction, rare in fiction.
+A glossary defines specialized terms used in the text — common in fantasy, sci-fi, and technical nonfiction.
+An index is essential in nonfiction for discoverability; created professionally by an indexer.
+Discussion questions (a reading group guide) can appear at the back and help with book club adoption.
+An appendix contains supplementary material referenced in the text but too detailed for the main body.
+"About the Author" is a short third-person bio, typically 100–200 words, placed in back matter.
+A colophon is a production note at the back describing the typefaces and design choices used in the book.
+
+# ── Chapter & Scene Structure ────────────────────────────────────────────────
+Most traditionally published novels have 10–30 chapters.
+Thriller chapters are often kept short — 1,500–3,000 words — to increase pace and create cliffhangers.
+Literary fiction chapters tend to be longer, sometimes 5,000–10,000 words.
+A scene is a unit of action occurring in a continuous time and place with a clear goal and outcome.
+A chapter typically contains 1–5 scenes, depending on pacing and genre conventions.
+Scene breaks within a chapter are marked by a blank line or a centered symbol (# or * * *).
+A part is a larger structural division grouping multiple chapters under a theme or act.
+An act structure (three-act, five-act) is a way to think about large narrative arcs, not a formatting element.
+Chapter titles are optional in fiction; they are more common in nonfiction and middle grade/YA.
+Numbered chapters ("Chapter 1") can be spelled out ("Chapter One") — pick one style and stick to it.
+
+# ── Manuscript Formatting Standards ─────────────────────────────────────────
+Standard manuscript format uses 12pt Times New Roman or Courier, double-spaced, 1-inch margins.
+Manuscripts are formatted with a header on each page: author name / short title / page number.
+The first page of a manuscript begins with contact information in the top-left corner.
+Chapters begin on a new page, with the chapter heading centered roughly 1/3 down the page.
+Paragraph indents in manuscripts are 0.5 inches; there is no extra space between paragraphs.
+Scene breaks in manuscripts use a centered "#" on its own line.
+"The End" is traditionally typed centered after the final line of a manuscript.
+Word count in a submission query is rounded to the nearest 1,000 (e.g., "complete at 87,000 words").
+Agents and editors use manuscript word count, not publisher's print word count — they differ slightly.
+Italics in manuscripts are formatted as actual italics (not underlined, as was done on typewriters).
+
+# ── Typography & Design ──────────────────────────────────────────────────────
+Most print books use 10–12pt serif fonts (Garamond, Caslon, Minion Pro, Sabon) for body text.
+Nonfiction often uses sans-serif fonts (Myriad, Helvetica Neue) for headings with serif body text.
+Leading (line spacing) in printed books is typically 120–145% of the font size.
+An em dash (—) is used for parenthetical statements; it has no spaces on either side in US style.
+An en dash (–) is used for ranges (pages 10–20, 1939–1945) and compound modifiers.
+Ellipses in published books are typically three dots with thin spaces between (. . .) or a special character (…).
+A widow is a single word or short line stranded at the top of a page — avoided in final typesetting.
+An orphan is the first line of a paragraph stranded at the bottom of a page — also avoided.
+Running heads (headers at the top of each page) typically alternate: book title on verso, chapter title on recto.
+Page numbers (folios) can be omitted on chapter-opening pages and other display pages.
+The recto is the right-hand (odd-numbered) page; the verso is the left-hand (even-numbered) page.
+Chapters always begin on recto pages in traditionally typeset books.
+ISBN stands for International Standard Book Number; print and ebook editions each require their own ISBN.
+The spine of a book is readable when the book is shelved with the spine facing outward — author name, title, publisher.
+
+# ── Publishing Industry Numbers ──────────────────────────────────────────────
+The average traditionally published novel takes 1–3 years from acceptance to bookstore shelves.
+A debut author's advance is typically $5,000–$15,000 for genre fiction; much higher for high-profile acquisitions.
+Royalties on print books are typically 10–15% of the cover price (or net receipts).
+Ebook royalties for traditionally published authors are typically 25% of net receipts.
+Self-published authors earn 35–70% royalty on ebooks depending on platform and pricing.
+The "Big Five" publishers (Penguin Random House, HarperCollins, Simon & Schuster, Hachette, Macmillan) produce the majority of bestsellers.
+A literary agent typically takes 15% of domestic deals and 20% of foreign/subsidiary rights.
+The New York Times bestseller list requires approximately 5,000–10,000 sales in a single week, distributed across many outlets.
+Most books sell fewer than 1,000 copies in their lifetime — strong sales are rarer than they appear.
+A book is considered a bestseller on Amazon if it reaches #1 in its category, not the overall store.
+
+# ── Reading & Writing Pace ───────────────────────────────────────────────────
+The average adult reads 200–400 words per minute silently.
+Slow readers process about 100–200 words per minute; speed readers can reach 700+ wpm.
+At 250 words per minute, a 90,000-word novel takes about 6 hours to read.
+The average writer produces 500–1,500 words of usable prose per day.
+NaNoWriMo's 50,000-word goal requires 1,667 words per day for 30 days.
+Stephen King aims for 2,000 words per day; he considers it a minimum, not a ceiling.
+A 1,000-word-per-day habit produces a complete novel draft in about 3 months.
+Most authors report that revision takes longer than the first draft — often 2–5x as long.
+"The first draft of anything is garbage." — Ernest Hemingway (attributed)
+Writing 500 words daily for a year yields 182,500 words — roughly two novels.
+
+# ── Book Anatomy Miscellany ──────────────────────────────────────────────────
+The gutter is the inner margin of a page — wider than the outer margin to account for binding.
+Bleed is artwork or color that extends to the edge of the page before trimming — important in illustrated books.
+A galley is an early, uncorrected proof sent to reviewers before the final book is printed.
+An ARC (Advance Reader Copy) is a pre-publication proof distributed to reviewers and booksellers.
+A first edition is the first print run of a book; a first printing is the first batch of that edition.
+A trade paperback is larger (typically 6×9) than a mass market paperback (4.19×6.75 or 4.25×6.87).
+A perfect binding glues pages to the spine — used in most paperbacks.
+Sewn signatures (Smyth-sewn binding) are more durable than perfect binding — common in quality hardcovers.
+Folio is another word for page number, or the large-format book (12 inches or more tall) used in Shakespeare's time.
+A broadside was a single large sheet printed on one side — the predecessor to the newspaper and the pamphlet.
+The verso of the title page (copyright page) is among the most legally and catalogically important pages in a book.
+Librarians use the CIP (Cataloging in Publication) data on the copyright page to classify books.
+The BISAC subject code on the copyright page tells retailers which shelf a book belongs on.
+A colophon originally referred to a printer's device or logo; today it can also mean production notes at the book's end.

--- a/src/book_editor/services/__init__.py
+++ b/src/book_editor/services/__init__.py
@@ -23,6 +23,14 @@ from book_editor.services.github_app import (
 )
 from book_editor.services.pdf_build import build_pdf, get_latest_chapter_files, check_pandoc_available, check_pdflatex_available
 from book_editor.services.auto_version import classify_change
+from book_editor.services.matter import (
+    FRONT_MATTER_ORDER,
+    BACK_MATTER_ORDER,
+    list_matter_sections,
+    create_matter_section,
+    delete_matter_section,
+    get_all_matter_files,
+)
 from book_editor.services.planning import (
     planning_dir,
     ensure_planning_structure,
@@ -63,4 +71,10 @@ __all__ = [
     "create_planning_folder",
     "delete_planning_entry",
     "classify_change",
+    "FRONT_MATTER_ORDER",
+    "BACK_MATTER_ORDER",
+    "list_matter_sections",
+    "create_matter_section",
+    "delete_matter_section",
+    "get_all_matter_files",
 ]

--- a/src/book_editor/services/chapter_version.py
+++ b/src/book_editor/services/chapter_version.py
@@ -128,6 +128,18 @@ class ChapterVersionManager:
             return int(match.group(1))
         return 0
 
+    def bump_section_dir(self, section_dir: Path, bump_type: str) -> Path:
+        """Generic version bump for any named section dir (matter or chapter)."""
+        latest = self.get_latest_version(section_dir)
+        current = self.parse_version(latest.name)
+        md_file = self.get_markdown_file(latest)
+        new_ver = self.increment_version(current, bump_type)
+        new_ver_str = self.format_version(*new_ver)
+        new_dir = section_dir / new_ver_str
+        new_dir.mkdir(exist_ok=False)
+        shutil.copy2(md_file, new_dir / md_file.name)
+        return new_dir
+
     def list_chapters(self):
         """List all chapters with their current versions"""
         if not self.chapters_dir.exists():

--- a/src/book_editor/services/matter.py
+++ b/src/book_editor/services/matter.py
@@ -1,0 +1,97 @@
+"""Front matter and back matter section management."""
+
+import shutil
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from book_editor.services.chapter_version import ChapterVersionManager
+
+
+FRONT_MATTER_ORDER: List[str] = [
+    "Copyright",
+    "Dedication",
+    "Epigraph",
+    "Foreword",
+    "Preface",
+    "Prologue",
+    "Acknowledgements",
+]
+
+BACK_MATTER_ORDER: List[str] = [
+    "Epilogue",
+    "Afterword",
+    "Appendix",
+    "Sources",
+    "Glossary",
+    "Index",
+    "Acknowledgements",
+    "About the Author",
+    "Preview",
+    "Call to Action",
+]
+
+
+def _matter_dir(repo_path: str, kind: str) -> Path:
+    """Return Path to FrontMatter/ or BackMatter/ directory."""
+    if kind == "front":
+        return Path(repo_path) / "FrontMatter"
+    elif kind == "back":
+        return Path(repo_path) / "BackMatter"
+    else:
+        raise ValueError(f"kind must be 'front' or 'back', got: {kind!r}")
+
+
+def _canonical_order(kind: str) -> List[str]:
+    return FRONT_MATTER_ORDER if kind == "front" else BACK_MATTER_ORDER
+
+
+def list_matter_sections(repo_path: str, kind: str) -> List[Tuple[str, Path]]:
+    """Return list of (name, latest_md_path) in canonical order for existing sections."""
+    base = _matter_dir(repo_path, kind)
+    if not base.exists():
+        return []
+    manager = ChapterVersionManager()
+    result = []
+    for name in _canonical_order(kind):
+        section_dir = base / name
+        if not section_dir.is_dir():
+            continue
+        try:
+            latest_ver = manager.get_latest_version(section_dir)
+            md_path = manager.get_markdown_file(latest_ver)
+            result.append((name, md_path))
+        except Exception:
+            continue
+    return result
+
+
+# Sections whose content should be centered on the page (standard book formatting).
+# Applied transparently at PDF build time — source files stay as plain markdown.
+CENTERED_MATTER_SECTIONS: frozenset = frozenset({"Dedication", "Epigraph"})
+
+
+def create_matter_section(repo_path: str, kind: str, name: str) -> Path:
+    """Create a new matter section with v1.0.0 and return the md file Path."""
+    base = _matter_dir(repo_path, kind)
+    base.mkdir(exist_ok=True)
+    section_dir = base / name
+    if section_dir.exists():
+        raise ValueError(f"Section '{name}' already exists in {base.name}.")
+    ver_dir = section_dir / "v1.0.0"
+    ver_dir.mkdir(parents=True)
+    md_file = ver_dir / "v1.0.0.md"
+    md_file.write_text("", encoding="utf-8")
+    return md_file
+
+
+def delete_matter_section(repo_path: str, kind: str, name: str) -> None:
+    """Delete a matter section directory tree."""
+    base = _matter_dir(repo_path, kind)
+    section_dir = base / name
+    if section_dir.exists():
+        shutil.rmtree(section_dir)
+
+
+def get_all_matter_files(repo_path: str, kind: str) -> List[Path]:
+    """Return ordered list of latest md Paths for all existing matter sections."""
+    return [md for _name, md in list_matter_sections(repo_path, kind)]

--- a/src/book_editor/services/pdf_build.py
+++ b/src/book_editor/services/pdf_build.py
@@ -4,9 +4,11 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Iterator, List, Optional
 
 
 # ── Bundled binary resolution ──────────────────────────────────────────────────
@@ -126,6 +128,37 @@ def get_latest_chapter_files(chapters_dir: Path) -> List[Path]:
 # ── PDF generation ─────────────────────────────────────────────────────────────
 
 
+@contextmanager
+def _prepared_files(files: List[Path]) -> Iterator[List[str]]:
+    """Yield a list of file path strings for pandoc, wrapping centered sections in temp files."""
+    from book_editor.services.matter import CENTERED_MATTER_SECTIONS
+    tmp_files: List[tempfile.NamedTemporaryFile] = []
+    paths: List[str] = []
+    try:
+        for f in files:
+            section_name = f.parent.parent.name  # .../SectionName/vX.Y.Z/vX.Y.Z.md
+            if section_name in CENTERED_MATTER_SECTIONS:
+                content = f.read_text(encoding="utf-8")
+                wrapped = f"\\begin{{center}}\n{content}\n\\end{{center}}\n"
+                tmp = tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".md", delete=False, encoding="utf-8"
+                )
+                tmp.write(wrapped)
+                tmp.flush()
+                tmp.close()
+                tmp_files.append(tmp)
+                paths.append(tmp.name)
+            else:
+                paths.append(str(f))
+        yield paths
+    finally:
+        for tmp in tmp_files:
+            try:
+                Path(tmp.name).unlink(missing_ok=True)
+            except Exception:
+                pass
+
+
 def build_pdf(
     repo_path: str,
     output_path: Optional[Path] = None,
@@ -138,10 +171,13 @@ def build_pdf(
     to system PATH in dev mode.
     Returns the path to the generated PDF.
     """
-    chapters_dir = Path(repo_path) / "Chapters"
-    files = get_latest_chapter_files(chapters_dir)
+    from book_editor.services.matter import get_all_matter_files
+    front_files = get_all_matter_files(repo_path, "front")
+    chapter_files = get_latest_chapter_files(Path(repo_path) / "Chapters")
+    back_files = get_all_matter_files(repo_path, "back")
+    files = front_files + chapter_files + back_files
     if not files:
-        raise ValueError("No chapters found in Chapters/")
+        raise ValueError("No content found to build PDF.")
 
     if output_path is None:
         date_str = datetime.now().strftime("%Y-%m-%d")
@@ -150,28 +186,29 @@ def build_pdf(
     output_path = Path(output_path)
 
     date_str = datetime.now().strftime("%Y-%m-%d")
-    cmd = [
-        _resolve_bin("pandoc"),
-        *[str(f) for f in files],
-        "-o",
-        str(output_path),
-        "--pdf-engine=pdflatex",
-        "-V", "geometry:margin=1in",
-        "-V", "fontsize=12pt",
-        "-V", "documentclass=book",
-        "-V", "papersize=letter",
-        "--toc",
-        "--toc-depth=2",
-        "-V", f"title={title}",
-        "-V", f"author={author}",
-        "-V", f"date={date_str}",
-        "--highlight-style=tango",
-        "--number-sections",
-    ]
+    with _prepared_files(files) as file_paths:
+        cmd = [
+            _resolve_bin("pandoc"),
+            *file_paths,
+            "-o",
+            str(output_path),
+            "--pdf-engine=pdflatex",
+            "-V", "geometry:margin=1in",
+            "-V", "fontsize=12pt",
+            "-V", "documentclass=book",
+            "-V", "papersize=letter",
+            "--toc",
+            "--toc-depth=2",
+            "-V", f"title={title}",
+            "-V", f"author={author}",
+            "-V", f"date={date_str}",
+            "--highlight-style=tango",
+            "--number-sections",
+        ]
 
-    result = subprocess.run(
-        cmd, capture_output=True, text=True, cwd=repo_path, env=_augmented_env()
-    )
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=repo_path, env=_augmented_env()
+        )
     if result.returncode != 0:
         raise RuntimeError(
             f"Pandoc failed: {result.stderr or result.stdout or 'unknown error'}"

--- a/src/book_editor/services/repo.py
+++ b/src/book_editor/services/repo.py
@@ -136,10 +136,9 @@ def git_push(
     repo = Repo(repo_path)
     if repo.is_dirty(untracked_files=True):
         repo.git.add("Chapters/")
-        # Also stage planning notes if present
-        planning = Path(repo_path) / "planning"
-        if planning.exists():
-            repo.git.add("planning/")
+        for extra in ("FrontMatter", "BackMatter", "planning"):
+            if (Path(repo_path) / extra).exists():
+                repo.git.add(f"{extra}/")
         repo.index.commit(message)
     origin = repo.remotes.origin
     old_url = origin.url


### PR DESCRIPTION
What does this PR do?                                                                                                                                      

  Adds structured Front Matter and Back Matter sections to the Beckit editor, stored alongside Chapters/ in the repo. Each section is versioned identically
  to chapters (v1.0.0 folders). The sidebar gains two new panels — one above and one below chapters — each with a picker to add available sections. PDF
  builds now prepend front matter and append back matter around the chapter body.

  Also includes: book title display in the sidebar, book title input when creating a new repo (auto-converts to a valid slug), and a rotating book-facts
  ticker in the status bar.

  Type of change

  - New feature

  How to test

  1. Open a repo — sidebar shows Front Matter and Back Matter sections (empty)
  2. Click + on Front Matter → pick a section (e.g. Dedication) → file is created, opens in editor
  3. Edit and save → version bumps correctly (e.g. v1.0.1)
  4. Add a Back Matter section (e.g. Epilogue) the same way
  5. Build PDF → front matter appears before Chapter 1, back matter after the last chapter
  6. Delete a section → folder removed, sidebar updates
  7. Open a repo that already has FrontMatter/ or BackMatter/ folders → items appear in sidebar on load
  8. Dedication and Epigraph content is centered in the generated PDF