### PR TITLE
fix: unblock editor scroll (replace GestureDetector)

### DIFF
--- a/src/book_editor/app.py
+++ b/src/book_editor/app.py
@@ -615,35 +615,22 @@ def main(page: ft.Page) -> None:
         _update_word_count_internal()
         page.update()
 
-    # Preview layer: scrollable Markdown + transparent tap target on top
+    # Preview layer: scrollable Markdown.
+    # Using ft.Container(on_click=...) instead of ft.GestureDetector so that
+    # the click handler does not compete with the scroll view for pointer events.
     preview_layer = ft.Container(
         content=ft.Column(
             [
-                ft.GestureDetector(
-                    content=ft.Container(
-                        content=ft.Column(
-                            [
-                                # Placeholder shown when editor is empty and no chapter loaded
-                                _scratch_placeholder,
-                                ft.Container(
-                                    md_preview,
-                                    padding=ft.padding.symmetric(horizontal=48, vertical=32),
-                                    expand=True,
-                                ),
-                                # Clickable empty space below text to enter edit mode
-                                ft.GestureDetector(
-                                    content=ft.Container(height=200, expand=False),
-                                    on_tap=_enter_edit_mode,
-                                ),
-                            ],
-                            expand=True,
-                            spacing=0,
-                        ),
-                        bgcolor=_BG,
-                        expand=True,
-                    ),
-                    on_tap=_enter_edit_mode,
-                )
+                # Placeholder shown when editor is empty and no chapter loaded
+                _scratch_placeholder,
+                ft.Container(
+                    md_preview,
+                    padding=ft.padding.symmetric(horizontal=48, vertical=32),
+                    expand=True,
+                    on_click=_enter_edit_mode,
+                ),
+                # Empty space below text — also clickable to enter edit mode
+                ft.Container(height=200, expand=False, on_click=_enter_edit_mode),
             ],
             scroll=ft.ScrollMode.AUTO,
             expand=True,


### PR DESCRIPTION
## Summary

- The `preview_layer` wrapped its entire content in a `ft.GestureDetector(on_tap=_enter_edit_mode)`, which competed with the enclosing scroll view's gesture recogniser on macOS — swallowing trackpad and mouse-wheel scroll events
- Replaced with `ft.Container(on_click=_enter_edit_mode)` on each individually clickable child (`md_preview` container + empty space below), which does not participate in the gesture arena and allows scroll events to flow through normally

## Test plan

- [x] Open a chapter with enough content to require scrolling
- [x] Verify trackpad and mouse-wheel scroll works in preview mode
- [x] Verify clicking on the preview content still enters edit mode
- [x] Verify clicking the empty area below content still enters edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)